### PR TITLE
[RE-760] Edited pre-upgrade task to uncordon a node failing to drain

### DIFF
--- a/TERALYTICS.md
+++ b/TERALYTICS.md
@@ -11,3 +11,4 @@ Description
 |---|---|---|---|---|
 | 1  | docker.service not provisionned | 8f1eaba9f63b07461c0aaa38935d1a09242cf51 | [PR Link](https://github.com/kubernetes-sigs/kubespray/pull/6518) | In review by Kubespray  |
 | 2  | docker.socket fails to restart | 269a9bb2be0c0413136e96108ffe1a8235393fad | [Tera PR Link](https://github.com/teralytics/kubespray/pull/5) | No ideal solution found. Waiting for #1 to be merged first  |
+| 3  | Uncordon nodes failing to drain | 269a9bb2be0c0413136e96108ffe1a8235393fad | [Tera PR Link](https://github.com/teralytics/kubespray/pull/7) | In review in Teralytics  |

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -30,40 +30,46 @@
       false
       {%- endif %}
 
-- name: Cordon node
-  command: "{{ bin_dir }}/kubectl cordon {{ inventory_hostname }}"
-  delegate_to: "{{ groups['kube-master'][0] }}"
-  when: needs_cordoning
+- name: Node draining
+  block:
+    - name: Cordon node
+      command: "{{ bin_dir }}/kubectl cordon {{ inventory_hostname }}"
+      delegate_to: "{{ groups['kube-master'][0] }}"
 
-- name: Check kubectl version
-  command: "{{ bin_dir }}/kubectl version --client --short"
-  register: kubectl_version
-  delegate_to: "{{ groups['kube-master'][0] }}"
-  run_once: yes
-  changed_when: false
-  when:
-    - drain_nodes
-    - needs_cordoning
-    - drain_pod_selector
+    - name: Check kubectl version
+      command: "{{ bin_dir }}/kubectl version --client --short"
+      register: kubectl_version
+      delegate_to: "{{ groups['kube-master'][0] }}"
+      run_once: yes
+      changed_when: false
+      when:
+        - drain_nodes
+        - drain_pod_selector
 
-- name: Ensure minimum version for drain label selector if necessary
-  assert:
-    that: "kubectl_version.stdout.split(' ')[-1] is version('v1.10.0', '>=')"
-  when:
-    - drain_nodes
-    - needs_cordoning
-    - drain_pod_selector
+    - name: Ensure minimum version for drain label selector if necessary
+      assert:
+        that: "kubectl_version.stdout.split(' ')[-1] is version('v1.10.0', '>=')"
+      when:
+        - drain_nodes
+        - drain_pod_selector
 
-- name: Drain node
-  command: >-
-    {{ bin_dir }}/kubectl drain
-    --force
-    --ignore-daemonsets
-    --grace-period {{ drain_grace_period }}
-    --timeout {{ drain_timeout }}
-    --delete-local-data {{ inventory_hostname }}
-    {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
+    - name: Drain node
+      command: >-
+        {{ bin_dir }}/kubectl drain
+        --force
+        --ignore-daemonsets
+        --grace-period {{ drain_grace_period }}
+        --timeout {{ drain_timeout }}
+        --delete-local-data {{ inventory_hostname }}
+        {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
+      when:
+        - drain_nodes
+  rescue:
+    - name: Set node back to schedulable
+      command: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf uncordon {{ inventory_hostname }}"
+    - name: Fail after rescue
+      fail:
+        msg: "Failed to drain node {{ inventory_hostname }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
   when:
-    - drain_nodes
     - needs_cordoning


### PR DESCRIPTION
Intro
====
Part 2 of making the running of Kubespray upgrade-cluster.yml more reliable.
The issue was that Kubespray would cordon and then drain nodes when updating them. But when a node would fail to drain (for example because of no poddisruption budget), it would leave it cordoned.
This means repeated runs, failing, would cause more and more nodes to be left cordoned.

But if the node fails to drain, no upgrade is actually performed. So it is safe to uncordon it but STILL fail as the upgrade did not work.

Test
====
Tested the uncordoning after draining failure. Worked as expected.

Documentation
===========
None required.